### PR TITLE
Make equals symmetric

### DIFF
--- a/basic/.gitignore
+++ b/basic/.gitignore
@@ -1,1 +1,3 @@
 /target/
+.idea
+*.iml

--- a/basic/src/main/java/org/jvnet/jaxb2_commons/plugin/equals/EqualsPlugin.java
+++ b/basic/src/main/java/org/jvnet/jaxb2_commons/plugin/equals/EqualsPlugin.java
@@ -24,7 +24,6 @@ import org.xml.sax.ErrorHandler;
 
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JCodeModel;
-import com.sun.codemodel.JConditional;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JExpression;
@@ -183,9 +182,10 @@ public class EqualsPlugin extends AbstractParameterizablePlugin {
 			final JVar equalsStrategy = equals.param(EqualsStrategy.class,
 					"strategy");
 
-			final JConditional ifNotInstanceof = body._if(JOp.not(object
-					._instanceof(theClass)));
-			ifNotInstanceof._then()._return(JExpr.FALSE);
+            JExpression objectIsNull = object.eq(JExpr._null());
+            JExpression notTheSameType = JExpr.invoke("getClass").ne(object.invoke("getClass"));
+            body._if(JOp.cor(objectIsNull, notTheSameType))
+                    ._then()._return(JExpr.FALSE);
 
 			//
 			body._if(JExpr._this().eq(object))._then()._return(JExpr.TRUE);


### PR DESCRIPTION
Hi,

I think the generated equals code is somewhat flawed by creating equals methods that are not symmetric. We actually had a problem with this in our project, because adding a supertype to a HashSet would prevent any subtype with no preinitialized properties to be added to the Set, while the other way around adding is possible (the instanceof check instead of type equality). Thus this can lead to really erratic behavior (in our case we injected multibound generated classes via Guice and depending on the order Guice decided to add these types to the Set to inject, we ended up with a different amount of elements).

Greetings,
Peter