### PR TITLE
Upgrade beanutils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
 			<dependency>
 				<groupId>commons-beanutils</groupId>
 				<artifactId>commons-beanutils</artifactId>
-				<version>1.9.2</version>
+				<version>1.9.3</version>
 				<exclusions>
 					<exclusion>
 						<groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,11 @@
 					<version>1.9</version>
 				</plugin>
 				<plugin>
+					<groupId>org.owasp</groupId>
+					<artifactId>dependency-check-maven</artifactId>
+					<version>1.4.5</version>
+				</plugin>
+				<plugin>
 					<groupId>org.jvnet.jaxb2.maven2</groupId>
 					<artifactId>maven-jaxb2-plugin</artifactId>
 					<version>${maven-jaxb2-plugin.version}</version>


### PR DESCRIPTION
Hello. :)

I checked this project with DependencyCheck and found that several modules depend on an older version of commons-collections with a known vulnerability:
```
One or more dependencies were identified with known vulnerabilities in JAXB2 Basics - Full Plugins JAR:

commons-collections-3.2.1.jar (commons-collections:commons-collections:3.2.1, cpe:/a:apache:commons_collections:3.2.1) : CVE-2015-6420
```

Turns out this is pulled in via an older version of commons-beanutils, so I've upgraded that to the latest release. See http://commons.apache.org/proper/commons-beanutils/javadocs/v1.9.3/RELEASE-NOTES.txt for more details

According to DependencyCheck (`mvn dependency-check:check`), it looks like one of the modules also depends on some older versions of spring, but I haven't looked closer at this.

`mvn clean install` still ran successfully.