### PR TITLE
[Fix] Update AbstractSamplesTest to properly handle base directories with special characters (e.g. spaces)

### DIFF
--- a/testing/src/main/java/org/jvnet/jaxb2_commons/test/AbstractSamplesTest.java
+++ b/testing/src/main/java/org/jvnet/jaxb2_commons/test/AbstractSamplesTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractSamplesTest extends TestCase {
 	protected File getBaseDir() {
 		try {
 			return (new File(getTestClass().getProtectionDomain()
-					.getCodeSource().getLocation().getFile())).getParentFile()
+					.getCodeSource().getLocation().toURI())).getParentFile()
 					.getParentFile().getAbsoluteFile();
 		} catch (Exception ex) {
 			throw new AssertionError(ex);


### PR DESCRIPTION
The `getFile` here is returning a `String` that is potentially adding escaping characters (e.g. '%20').  The `java.ioFile` can natively take a URI as a parameter, so avoid trying to convert the path to a string, and simply avoid the issue.

```
[INFO] JAXB2 Basics - Project ............................. SUCCESS [  0.129 s]
[INFO] JAXB2 Basics - Ant Task ............................ SUCCESS [  3.454 s]
[INFO] JAXB2 Basics - Runtime ............................. SUCCESS [  6.756 s]
[INFO] JAXB2 Basics - Tools ............................... SUCCESS [  3.976 s]
[INFO] JAXB2 Basics - Testing ............................. SUCCESS [  3.436 s]
[INFO] JAXB2 Basics - Basic Plugins ....................... SUCCESS [  3.529 s]
[INFO] JAXB2 Basics - Full Plugins JAR .................... SUCCESS [  0.375 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 21.843 s
[INFO] Finished at: 2019-01-12T16:11:09+00:00
[INFO] Final Memory: 23M/291M
[INFO] ------------------------------------------------------------------------
```