### PR TITLE
search accessible clone() to fix java17 compatability (#130)

### DIFF
--- a/runtime/src/test/java/org/jvnet/jaxb2_commons/lang/tests/CopyStrategyTest.java
+++ b/runtime/src/test/java/org/jvnet/jaxb2_commons/lang/tests/CopyStrategyTest.java
@@ -8,11 +8,16 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
 import junit.framework.TestCase;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
 import org.jvnet.jaxb2_commons.lang.CopyStrategy2;
 import org.jvnet.jaxb2_commons.lang.CopyTo2;
+import org.jvnet.jaxb2_commons.lang.DefaultCopyStrategy;
 import org.jvnet.jaxb2_commons.lang.JAXBCopyStrategy;
 import org.jvnet.jaxb2_commons.locator.ObjectLocator;
 
@@ -48,6 +53,15 @@ public class CopyStrategyTest extends TestCase {
 		} finally {
 			IOUtils.closeQuietly(is);
 		}
+	}
+
+	public void testXMLGregorianCalendar() throws Exception {
+		final XMLGregorianCalendar calendar = DatatypeFactory.newInstance().newXMLGregorianCalendar("2022-01-14");
+		final Object copyObj = new DefaultCopyStrategy().copy(null, calendar);
+		Assert.assertTrue(copyObj instanceof XMLGregorianCalendar);
+		Assert.assertEquals(calendar, copyObj);
+		Assert.assertNotSame(calendar, copyObj);
+		Assert.assertEquals("2022-01-14", ((XMLGregorianCalendar) copyObj).toXMLFormat());
 	}
 
 	@XmlRootElement(name = "a")


### PR DESCRIPTION
XMLGregorianCalender is not cloneable with the current implementation when using java 17. The implementation did not select the method `XMLGregorianCalendar.clone()` which is accessible to anyone, but rather the method `XMLGregorianCalenderImpl.clone()` to which access is prohibited in recent java versions ending up in an IllegalAccessError.

This fixes the problem by searching for the first clone() method in the classes hierarchy that is public and accessible. This removes the need of calling `setAccessible()` because the method will be accessible. For java8 it will still use the old logic because `Method.canAccess()` does not exist until java9.

(This is a possible fix for #130)